### PR TITLE
Loot value parser

### DIFF
--- a/LootchasersAPI/Controllers/RuneliteController.cs
+++ b/LootchasersAPI/Controllers/RuneliteController.cs
@@ -13,7 +13,8 @@ public class RuneliteController : ControllerBase
     private record Payload(string content);
     #pragma warning restore IDE1006 // Naming Styles
     private readonly IHttpClientFactory _httpClientFactory;
-    
+    private static readonly long LootValueThreshold = 2_000_000;
+
     public RuneliteController(IHttpClientFactory httpClientFactory)
     {
         _httpClientFactory = httpClientFactory;
@@ -63,7 +64,7 @@ public class RuneliteController : ControllerBase
             var totalValueStr = JsonParser.GetNodeFromJson(payloadJson!, "totalValue");
             var totalValue = JsonParser.ParseStackValue(totalValueStr);
 
-            if (totalValue < 2_000_000)
+            if (totalValue < LootValueThreshold)
                 return BadRequest("Total value must be at least 2 million.");
         }
 

--- a/LootchasersAPI/Services/JsonParser.cs
+++ b/LootchasersAPI/Services/JsonParser.cs
@@ -21,5 +21,31 @@ namespace LootchasersAPI.Services
 
             return null;
         }
+        public static long ParseStackValue(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return 0;
+            }
+
+            input = input.Trim().ToUpperInvariant();
+
+            if (input.EndsWith("M"))
+            {
+                if (double.TryParse(input.TrimEnd('M'), out var mVal))
+                    return (long)(mVal * 1_000_000);
+            }
+            else if (input.EndsWith("K"))
+            {
+                if (double.TryParse(input.TrimEnd('K'), out var kVal))
+                    return (long)(kVal * 1_000);
+            }
+            else if (long.TryParse(input.Replace(",", ""), out var plainVal))
+            {
+                return plainVal;
+            }
+
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Added ParseStackValue to the JsonParser service to handle loot values that are in K and M.

Added a check against any LOOT webhook posts to be at least 2m coins after parsing the json totalValue